### PR TITLE
Fallback setting to editor.rulers before editor.wordWrapColumn

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,8 @@ class ReflowParameters {
     if (this.wrapColumn === 0) {
       // The wrap column wasn't specified, so default to editor.wordWrapColumn.
       const editorConfig = vscode.workspace.getConfiguration('editor', scope)
-      this.wrapColumn = editorConfig.get<number>('wordWrapColumn') as number;
+      this.wrapColumn = editorConfig.get('rulers', [])[0] ||
+          (editorConfig.get<number>('wordWrapColumn') as number);
     }
     this.extraIndentForDescriptionList =
         config.get<number>('extraIndentForDescriptionList') as number;


### PR DESCRIPTION
I believe the editor.rulers setting more accurately reflects the user preference for the word wrap column width. This is used in other extensions such as Rewrap:
https://github.com/stkb/Rewrap/blob/6a27098e20baf95759c621a5cc1cd9b3fedbd9ed/vscode/src/Settings.ts#L72