### PR TITLE
Mark reflowlist.wrapColumn setting as language-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "reflowlist.wrapColumn": {
           "type": "integer",
           "default": 0,
-          "description": "What column to wrap at.  If 0, then we use editor.wordWrapColumn."
+          "description": "What column to wrap at.  If 0, then we use editor.wordWrapColumn.",
+          "scope": "language-overridable"
         },
         "reflowlist.extraIndentForDescriptionList": {
           "type": "integer",


### PR DESCRIPTION
This prevents a warning in the settings JSON editor.