### PR TITLE
Add Swift documentation comments (`///`) to the default comment regex.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "properties": {
         "reflowlist.commentRegexp": {
           "type": "string",
-          "default": "^\\s*(?://|#|--|\\>)",
+          "default": "^\\s*(?:///|//|#|--|\\>)",
           "description": "Regular expression matching comments to reformat.  This does not include ' * ' for multiline /* ... */ comments; these are handled separately."
         },
         "reflowlist.listStartRegexp": {


### PR DESCRIPTION
It'd be great to use this extension for reflowing Swift doc comments. Swift uses `///` as the prefix for documentation comments. Reference: https://developer.apple.com/documentation/xcode/writing-symbol-documentation-in-your-source-files